### PR TITLE
Fix deprecation warning in verify_expert_scenarios

### DIFF
--- a/001_forecast_veryfication.ipynb
+++ b/001_forecast_veryfication.ipynb
@@ -2386,7 +2386,7 @@
         "            \"share_O\": 1 - share_E - share_A\n",
         "        })\n",
         "\n",
-        "    summary_df = long.groupby(\"Scenario\").apply(_summarise).reset_index()\n",
+        "    summary_df = long.groupby(\"Scenario\").apply(_summarise, include_groups=False).reset_index()\n",
         "\n",
         "    return long.rename(columns={year_col: \"Year\"}), summary_df\n",
         "\n",


### PR DESCRIPTION
## Summary
- add `include_groups=False` when calling `groupby.apply`

## Testing
- `apt-get update`
- `apt-get install -y xlsx2csv`
- `pip install pandas`


------
https://chatgpt.com/codex/tasks/task_e_683f3de0ee448323960a1a8b1bd5137b